### PR TITLE
PR add parseEncrypt

### DIFF
--- a/.jsbeautifyrc
+++ b/.jsbeautifyrc
@@ -1,0 +1,7 @@
+{
+    "indent_size": 2,
+    "options": {
+        "camelcase": "2",
+        "space-before-function-paren": "2"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ service.manage.template(settings, app, 'TM00015', function (error, data ) {
 
 ```
 
+### 消息解密
+
+```js
+messages.parseEncrypt(appToken, appEncodingAESKey, query, body);
+
+```
+
 ## License
 
 Apache-2.0 © [calidion](calidion.github.io)

--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -3,6 +3,7 @@
 /* eslint-env es6 */
 var x2j = require('xml2js');
 var crypto = require('crypto');
+var util = require('node-weixin-util');
 
 var Emitter = require('events').EventEmitter;
 var emitter = new Emitter();
@@ -24,7 +25,7 @@ function htonl(n) {
 
 function padding(n) {
   var len = n % 32;
-  if (len === 0) { 
+  if (len === 0) {
     len = 32;
   } else {
     len = 32 - len;
@@ -102,7 +103,7 @@ module.exports = {
       eventEmitter.emit.apply(eventEmitter, args);
     }
   },
-  generateSignature: function(token, timestamp, nonce, msgSignature){
+  generateSignature: function(token, timestamp, nonce, msgSignature) {
     var mixes = [token, timestamp, nonce, msgSignature];
     mixes.sort();
     var str = mixes.join('');
@@ -110,44 +111,44 @@ module.exports = {
     sha1.update(str);
     return sha1.digest('hex');
   },
-  check: function (token, msgSignature, timestamp, nonce, msgEncrypt) {
+  check: function(token, msgSignature, timestamp, nonce, msgEncrypt) {
     var newSignature = this.generateSignature(token, timestamp, nonce, msgEncrypt);
     if (newSignature === msgSignature) {
       return true;
     }
     return false;
   },
-  decrypt: function(encodingAESKey, msgEncrypt){
+  decrypt: function(encodingAESKey, msgEncrypt) {
     var AESKey = Buffer.from(encodingAESKey + '=', 'base64');
     var iv = AESKey.slice(0, 16);
     const cipher = crypto.createDecipheriv('aes-256-cbc', AESKey, iv);
     cipher.setAutoPadding(false);
     var text = cipher.update(msgEncrypt, 'base64', 'utf8') + cipher.final('utf8');
-    return { 
-      nonce: text.substring(0, 16), 
+    return {
+      nonce: text.substring(0, 16),
       msg_len: text.substring(16, 20),
       xml: text.substring(20, text.lastIndexOf('>') + 1)
-    }
+    };
   },
-  encrypt: function(encodingAESKey, xml, appId){
+  encrypt: function(encodingAESKey, xml, appId) {
     var nonce = util.getNonce(16);
     var AESKey = Buffer.from(encodingAESKey + '=', 'base64');
     var iv = AESKey.slice(0, 16);
-    var preBuf = Buffer.from(nonce, 'utf8'),
-      msgBuf = Buffer.from(xml, 'utf8'),
-      msgBufLen = msgBuf.length,
-      netBuf = htonl(msgBufLen),
-      appIdBuf = Buffer.from(appId, 'utf8'),
-      appIdBufLen = appIdBuf.length,
-      paddingBuf = padding(20 + msgBufLen + appIdBufLen);
+    var preBuf = Buffer.from(nonce, 'utf8');
+    var msgBuf = Buffer.from(xml, 'utf8');
+    var msgBufLen = msgBuf.length;
+    var netBuf = htonl(msgBufLen);
+    var appIdBuf = Buffer.from(appId, 'utf8');
+    var appIdBufLen = appIdBuf.length;
+    var paddingBuf = padding(20 + msgBufLen + appIdBufLen);
     const cipher = crypto.createCipheriv('aes-256-cbc', AESKey, iv);
     cipher.setAutoPadding(false);
     return cipher.update(Buffer.concat([preBuf, netBuf, msgBuf, appIdBuf, paddingBuf]), 'binary', 'base64') + cipher.final('base64');
   },
   parseEncrypt: function(appToken, appEncodingAESKey, query, body) {
     var self = this;
-    if(query.encrypt_type && query.encrypt_type === 'aes'){
-      if(self.check(appToken, body.msg_signature, body.timestamp, body.nonce, body.xml.Encrypt)){
+    if (query.encrypt_type && query.encrypt_type === 'aes') {
+      if (self.check(appToken, body.msg_signature, body.timestamp, body.nonce, body.xml.Encrypt)) {
         self.onXML(self.decrypt(appEncodingAESKey, body.xml.Encrypt));
       } else {
         throw Error('Bad Message!');

--- a/lib/incoming.js
+++ b/lib/incoming.js
@@ -2,6 +2,7 @@
 /* eslint space-before-function-paren: [2, "never"] */
 /* eslint-env es6 */
 var x2j = require('xml2js');
+var crypto = require('crypto');
 
 var Emitter = require('events').EventEmitter;
 var emitter = new Emitter();
@@ -10,7 +11,30 @@ var ons = {};
 var eventOns = {};
 
 var types = ['text', 'image', 'voice', 'video', 'shortvideo', 'location', 'link'];
-var eventTypes = ['subscribe', 'unsubscribe', 'scan', 'location', 'click', 'view', 'templatesendjobfinish'];
+var eventTypes = ['subscribe', 'unsubscribe', 'scan', 'location', 'click', 'view', 'templatesendjobfinish', 'view_miniprogram'];
+
+function htonl(n) {
+  var buffer = Buffer.alloc(4);
+  buffer[0] = (n & 0xFF000000) >> 24;
+  buffer[1] = (n & 0x00FF0000) >> 16;
+  buffer[2] = (n & 0x0000FF00) >> 8;
+  buffer[3] = (n & 0x000000FF) >> 0;
+  return buffer;
+}
+
+function padding(n) {
+  var len = n % 32;
+  if (len === 0) { 
+    len = 32;
+  } else {
+    len = 32 - len;
+  }
+  var buffer = Buffer.alloc(len);
+  for (var i = 0; i < len; i++) {
+    buffer[i] = len;
+  }
+  return buffer;
+}
 
 function makeEventCall(emitter, ons, types) {
   for (var i = 0; i < types.length; i++) {
@@ -33,6 +57,10 @@ makeEventCall(emitter, ons, types);
 makeEventCall(eventEmitter, eventOns, eventTypes);
 
 module.exports = {
+  setMaxListeners: function(maxListeners) {
+    emitter.setMaxListeners(maxListeners);
+    eventEmitter.setMaxListeners(maxListeners);
+  },
   on: ons,
   onXML: function(xml) {
     var self = this;
@@ -72,6 +100,60 @@ module.exports = {
         args.push(arguments[i]);
       }
       eventEmitter.emit.apply(eventEmitter, args);
+    }
+  },
+  generateSignature: function(token, timestamp, nonce, msgSignature){
+    var mixes = [token, timestamp, nonce, msgSignature];
+    mixes.sort();
+    var str = mixes.join('');
+    var sha1 = crypto.createHash('sha1');
+    sha1.update(str);
+    return sha1.digest('hex');
+  },
+  check: function (token, msgSignature, timestamp, nonce, msgEncrypt) {
+    var newSignature = this.generateSignature(token, timestamp, nonce, msgEncrypt);
+    if (newSignature === msgSignature) {
+      return true;
+    }
+    return false;
+  },
+  decrypt: function(encodingAESKey, msgEncrypt){
+    var AESKey = Buffer.from(encodingAESKey + '=', 'base64');
+    var iv = AESKey.slice(0, 16);
+    const cipher = crypto.createDecipheriv('aes-256-cbc', AESKey, iv);
+    cipher.setAutoPadding(false);
+    var text = cipher.update(msgEncrypt, 'base64', 'utf8') + cipher.final('utf8');
+    return { 
+      nonce: text.substring(0, 16), 
+      msg_len: text.substring(16, 20),
+      xml: text.substring(20, text.lastIndexOf('>') + 1)
+    }
+  },
+  encrypt: function(encodingAESKey, xml, appId){
+    var nonce = util.getNonce(16);
+    var AESKey = Buffer.from(encodingAESKey + '=', 'base64');
+    var iv = AESKey.slice(0, 16);
+    var preBuf = Buffer.from(nonce, 'utf8'),
+      msgBuf = Buffer.from(xml, 'utf8'),
+      msgBufLen = msgBuf.length,
+      netBuf = htonl(msgBufLen),
+      appIdBuf = Buffer.from(appId, 'utf8'),
+      appIdBufLen = appIdBuf.length,
+      paddingBuf = padding(20 + msgBufLen + appIdBufLen);
+    const cipher = crypto.createCipheriv('aes-256-cbc', AESKey, iv);
+    cipher.setAutoPadding(false);
+    return cipher.update(Buffer.concat([preBuf, netBuf, msgBuf, appIdBuf, paddingBuf]), 'binary', 'base64') + cipher.final('base64');
+  },
+  parseEncrypt: function(appToken, appEncodingAESKey, query, body) {
+    var self = this;
+    if(query.encrypt_type && query.encrypt_type === 'aes'){
+      if(self.check(appToken, body.msg_signature, body.timestamp, body.nonce, body.xml.Encrypt)){
+        self.onXML(self.decrypt(appEncodingAESKey, body.xml.Encrypt));
+      } else {
+        throw Error('Bad Message!');
+      }
+    } else {
+      self.parse(body.xml);
     }
   }
 };

--- a/test/custome-service.js
+++ b/test/custome-service.js
@@ -11,6 +11,16 @@ var settings = require('node-weixin-settings');
 
 var service = nodeWeixinMessage.service;
 
+global.token = {};
+
+settings.registerSet((id, key, value) => {
+  global.token = value;
+});
+
+settings.registerGet((id, key, cb) => {
+  cb(global.token);
+});
+
 var app = {
   id: process.env.APP_ID,
   secret: process.env.APP_SECRET,
@@ -30,10 +40,10 @@ describe('node-weixin-message', function() {
   describe('#api', function() {
     it('it should be able to handle text event', function(done) {
       service.api.text(settings, app, process.env.APP_OPENID, 'hello', function(error, data) {
-        assert.equal(true, !error);
+        assert.strictEqual(true, !error);
         if (data.errcode !== 45015) {
-          assert.equal(true, data.errcode === 0);
-          assert.equal(true, data.errmsg === 'ok');
+          assert.strictEqual(true, data.errcode === 0);
+          assert.strictEqual(true, data.errmsg === 'ok');
         }
         done();
       });
@@ -45,10 +55,10 @@ describe('node-weixin-message', function() {
         // json.media_id
 
         var callback = function(error, data) {
-          assert.equal(true, !error);
+          assert.strictEqual(true, !error);
           if (data.errcode !== 45015) {
-            assert.equal(true, data.errcode === 0);
-            assert.equal(true, data.errmsg === 'ok');
+            assert.strictEqual(true, data.errcode === 0);
+            assert.strictEqual(true, data.errmsg === 'ok');
           }
           done();
         };
@@ -72,10 +82,10 @@ describe('node-weixin-message', function() {
         // json.type
         // json.media_id
         service.api.voice(settings, app, process.env.APP_OPENID, json.media_id, function(error, data) {
-          assert.equal(true, !error);
+          assert.strictEqual(true, !error);
           if (data.errcode !== 45015) {
-            assert.equal(true, data.errcode === 0);
-            assert.equal(true, data.errmsg === 'ok');
+            assert.strictEqual(true, data.errcode === 0);
+            assert.strictEqual(true, data.errmsg === 'ok');
           }
           done();
         });
@@ -88,10 +98,10 @@ describe('node-weixin-message', function() {
         // json.type
         // json.media_id
         service.api.video(settings, app, process.env.APP_OPENID, 'title', 'desc', json.media_id, shareId, function(error, data) {
-          assert.equal(true, !error);
+          assert.strictEqual(true, !error);
           if (data.errcode !== 45015) {
-            assert.equal(true, data.errcode === 0);
-            assert.equal(true, data.errmsg === 'ok');
+            assert.strictEqual(true, data.errcode === 0);
+            assert.strictEqual(true, data.errmsg === 'ok');
           }
           done();
         });
@@ -106,10 +116,10 @@ describe('node-weixin-message', function() {
         'title',
         'desc',
         function(error, data) {
-          assert.equal(true, !error);
+          assert.strictEqual(true, !error);
           if (data.errcode !== 45015) {
-            assert.equal(true, data.errcode === 0);
-            assert.equal(true, data.errmsg === 'ok');
+            assert.strictEqual(true, data.errcode === 0);
+            assert.strictEqual(true, data.errmsg === 'ok');
           }
           done();
         });
@@ -129,10 +139,10 @@ describe('node-weixin-message', function() {
       }];
 
       service.api.news(settings, app, process.env.APP_OPENID, articles, function(error, data) {
-        assert.equal(true, !error);
+        assert.strictEqual(true, !error);
         if (data.errcode !== 45015) {
-          assert.equal(true, data.errcode === 0);
-          assert.equal(true, data.errmsg === 'ok');
+          assert.strictEqual(true, data.errcode === 0);
+          assert.strictEqual(true, data.errmsg === 'ok');
         }
         done();
       });
@@ -141,27 +151,27 @@ describe('node-weixin-message', function() {
   describe('#account', function() {
     it('it should be able to add an account', function(done) {
       service.account.add(settings, app, 'test1@test', '96e79218965eb72c92a549dd5a330112', 'guest1', function(error, data) {
-        assert.equal(true, !error);
+        assert.strictEqual(true, !error);
         console.log(data);
-        assert.equal(true, !data.errcode || data.errcode === 61450);
-        assert.equal(true, data.errmsg === 'ok' || data.errmsg === 'system error');
+        assert.strictEqual(true, !data.errcode || data.errcode === 61450);
+        assert.strictEqual(true, data.errmsg === 'ok' || data.errmsg === 'system error');
         done();
       });
     });
 
     it('it should be able to update an account', function(done) {
       service.account.update(settings, app, 'test1@test', '96e79218965eb72c92a549dd5a330112', 'guest1', function(error, data) {
-        assert.equal(true, !error);
-        assert.equal(true, Boolean(data));
+        assert.strictEqual(true, !error);
+        assert.strictEqual(true, Boolean(data));
         done();
       });
     });
 
     it('it should be able to delete an account', function(done) {
       service.account.remove(settings, app, 'test1@test', '96e79218965eb72c92a549dd5a330112', 'guest1', function(error, data) {
-        assert.equal(true, !error);
-        assert.equal(true, data.errcode === 0 || data.errcode === 61451);
-        assert.equal(true, data.errmsg === 'ok' || data.errmsg === 'invalid parameter');
+        assert.strictEqual(true, !error);
+        assert.strictEqual(true, data.errcode === 0 || data.errcode === 61451);
+        assert.strictEqual(true, data.errmsg === 'ok' || data.errmsg === 'invalid parameter');
         done();
       });
     });
@@ -170,8 +180,8 @@ describe('node-weixin-message', function() {
   describe('#account', function() {
     it('it should be able to test rawRequest', function(done) {
       service._rawRequest(settings, app, 'http://www.none100.com/', function(error, data) {
-        assert.equal(true, error);
-        assert.equal(true, Boolean(data));
+        assert.strictEqual(true, error);
+        assert.strictEqual(true, Boolean(data));
         done();
       });
     });
@@ -179,24 +189,24 @@ describe('node-weixin-message', function() {
     it('it should be able to update avatar', function(done) {
       var file = path.resolve(__dirname, './media/test.jpg');
       service.account.avatar(settings, app, 'kf001', file, function(error, data) {
-        assert.equal(true, !error);
-        assert.equal(true, Boolean(data));
+        assert.strictEqual(true, !error);
+        assert.strictEqual(true, Boolean(data));
         done();
       });
     });
     it('it should be able to list kfs', function(done) {
       service.account.list(settings, app, function(error, data) {
-        assert.equal(true, !error);
-        assert.equal(true, Boolean(data));
-        // assert.equal(true, Boolean(data).kf_online_list.length >= 0);
+        assert.strictEqual(true, !error);
+        assert.strictEqual(true, Boolean(data));
+        // assert.strictEqual(true, Boolean(data).kf_online_list.length >= 0);
         done();
       });
     });
     it('it should be able to list online kfs', function(done) {
       service.account.online(settings, app, function(error, data) {
-        assert.equal(true, !error);
-        assert.equal(true, Boolean(data));
-        // assert.equal(true, Boolean(data).kf_online_list.length >= 0);
+        assert.strictEqual(true, !error);
+        assert.strictEqual(true, Boolean(data));
+        // assert.strictEqual(true, Boolean(data).kf_online_list.length >= 0);
         done();
       });
     });
@@ -205,22 +215,22 @@ describe('node-weixin-message', function() {
   describe('#manage', function() {
     it('it should be able to set industry', function(done) {
       service.manage.industry(settings, app, 1, 2, function(error, data) {
-        assert.equal(true, !data.errcode || data.errcode === 43100);
+        assert.strictEqual(true, !data.errcode || data.errcode === 43100);
         done();
       });
     });
     it('it should be able to get template id', function(done) {
       service.manage.template(settings, app, 'TM00015', function(error, data) {
-        assert.equal(true, Boolean(data));
-        assert.equal(true, typeof data.template_id === 'string' || Boolean(data.errmsg));
+        assert.strictEqual(true, Boolean(data));
+        assert.strictEqual(true, typeof data.template_id === 'string' || Boolean(data.errmsg));
         done();
       });
     });
 
     it('it should be able to send template msg', function(done) {
       service.manage.template(settings, app, 'TM00015', function(error, data) {
-        assert.equal(true, Boolean(data));
-        assert.equal(true, typeof data.template_id === 'string' || Boolean(data.errmsg));
+        assert.strictEqual(true, Boolean(data));
+        assert.strictEqual(true, typeof data.template_id === 'string' || Boolean(data.errmsg));
         done();
       });
     });

--- a/test/events.js
+++ b/test/events.js
@@ -17,11 +17,11 @@ describe('node-weixin-message', function() {
       var messages = nodeWeixinMessage.messages;
 
       messages.event.on.subscribe(function(message) {
-        assert.equal(true, message.FromUserName === 'fromUser');
-        assert.equal(true, message.ToUserName === 'toUser');
-        assert.equal(true, message.CreateTime === '123456789');
-        assert.equal(true, message.MsgType === 'event');
-        assert.equal(true, message.Event === 'subscribe');
+        assert.strictEqual(true, message.FromUserName === 'fromUser');
+        assert.strictEqual(true, message.ToUserName === 'toUser');
+        assert.strictEqual(true, message.CreateTime === '123456789');
+        assert.strictEqual(true, message.MsgType === 'event');
+        assert.strictEqual(true, message.Event === 'subscribe');
         done();
       });
       var xml = fs.readFileSync(path.resolve(__dirname, './events/subscribe.xml'));
@@ -37,11 +37,11 @@ describe('node-weixin-message', function() {
       var messages = nodeWeixinMessage.messages;
 
       messages.event.on.unsubscribe(function(message) {
-        assert.equal(true, message.FromUserName === 'fromUser');
-        assert.equal(true, message.ToUserName === 'toUser');
-        assert.equal(true, message.CreateTime === '123456789');
-        assert.equal(true, message.MsgType === 'event');
-        assert.equal(true, message.Event === 'unsubscribe');
+        assert.strictEqual(true, message.FromUserName === 'fromUser');
+        assert.strictEqual(true, message.ToUserName === 'toUser');
+        assert.strictEqual(true, message.CreateTime === '123456789');
+        assert.strictEqual(true, message.MsgType === 'event');
+        assert.strictEqual(true, message.Event === 'unsubscribe');
         done();
       });
       var xml = fs.readFileSync(path.resolve(__dirname, './events/unsubscribe.xml'));
@@ -59,8 +59,8 @@ describe('node-weixin-message', function() {
 
       for (var k in messages.event.on) {
         if (typeof k === 'string') {
-          assert.equal(true, lists.indexOf(k) !== -1);
-          assert.equal(true, typeof messages.event.on[k] === 'function');
+          assert.strictEqual(true, lists.indexOf(k) !== -1);
+          assert.strictEqual(true, typeof messages.event.on[k] === 'function');
         }
       }
     });

--- a/test/incoming.js
+++ b/test/incoming.js
@@ -11,17 +11,24 @@ var path = require('path');
 
 var x2j = require('xml2js');
 
+var app = {
+  id: process.env.APP_ID,
+  secret: process.env.APP_SECRET,
+  token: process.env.APP_TOKEN,
+  encodingaeskey: process.env.APP_ENCODINGAESKEY
+};
+
 describe('node-weixin-message', function() {
   it('it should be able to handle incoming text', function(done) {
     var messages = nodeWeixinMessage.messages;
 
     messages.on.text(function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1348831860');
-      assert.equal(true, message.MsgType === 'text');
-      assert.equal(true, message.Content === 'this is a test');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1348831860');
+      assert.strictEqual(true, message.MsgType === 'text');
+      assert.strictEqual(true, message.Content === 'this is a test');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/text.xml'));
@@ -37,13 +44,13 @@ describe('node-weixin-message', function() {
     var messages = nodeWeixinMessage.messages;
 
     messages.on.image(function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1348831860');
-      assert.equal(true, message.MsgType === 'image');
-      assert.equal(true, message.PicUrl === 'this is a url');
-      assert.equal(true, message.MediaId === 'media_id');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1348831860');
+      assert.strictEqual(true, message.MsgType === 'image');
+      assert.strictEqual(true, message.PicUrl === 'this is a url');
+      assert.strictEqual(true, message.MediaId === 'media_id');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/image.xml'));
@@ -58,14 +65,14 @@ describe('node-weixin-message', function() {
   it('it should be able to handle incoming voice', function(done) {
     var messages = nodeWeixinMessage.messages;
     messages.on.voice(function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1357290913');
-      assert.equal(true, message.MsgType === 'voice');
-      assert.equal(true, message.Format === 'Format');
-      assert.equal(true, message.Recognition === '腾讯微信团队');
-      assert.equal(true, message.MediaId === 'media_id');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1357290913');
+      assert.strictEqual(true, message.MsgType === 'voice');
+      assert.strictEqual(true, message.Format === 'Format');
+      assert.strictEqual(true, message.Recognition === '腾讯微信团队');
+      assert.strictEqual(true, message.MediaId === 'media_id');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/voice.xml'));
@@ -81,13 +88,13 @@ describe('node-weixin-message', function() {
     var messages = nodeWeixinMessage.messages;
 
     messages.on.video(function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1357290913');
-      assert.equal(true, message.MsgType === 'video');
-      assert.equal(true, message.ThumbMediaId === 'thumb_media_id');
-      assert.equal(true, message.MediaId === 'media_id');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1357290913');
+      assert.strictEqual(true, message.MsgType === 'video');
+      assert.strictEqual(true, message.ThumbMediaId === 'thumb_media_id');
+      assert.strictEqual(true, message.MediaId === 'media_id');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/video.xml'));
@@ -103,13 +110,13 @@ describe('node-weixin-message', function() {
     var messages = nodeWeixinMessage.messages;
 
     messages.on.shortvideo(function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1357290913');
-      assert.equal(true, message.MsgType === 'shortvideo');
-      assert.equal(true, message.ThumbMediaId === 'thumb_media_id');
-      assert.equal(true, message.MediaId === 'media_id');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1357290913');
+      assert.strictEqual(true, message.MsgType === 'shortvideo');
+      assert.strictEqual(true, message.ThumbMediaId === 'thumb_media_id');
+      assert.strictEqual(true, message.MediaId === 'media_id');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/shortvideo.xml'));
@@ -125,15 +132,15 @@ describe('node-weixin-message', function() {
     var messages = nodeWeixinMessage.messages;
 
     messages.on.location(function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1351776360');
-      assert.equal(true, message.MsgType === 'location');
-      assert.equal(true, message.Location_X === '23.134521');
-      assert.equal(true, message.Location_Y === '113.358803');
-      assert.equal(true, message.Scale === '20');
-      assert.equal(true, message.Label === '位置信息');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1351776360');
+      assert.strictEqual(true, message.MsgType === 'location');
+      assert.strictEqual(true, message.Location_X === '23.134521');
+      assert.strictEqual(true, message.Location_Y === '113.358803');
+      assert.strictEqual(true, message.Scale === '20');
+      assert.strictEqual(true, message.Label === '位置信息');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/location.xml'));
@@ -149,14 +156,14 @@ describe('node-weixin-message', function() {
     var messages = nodeWeixinMessage.messages;
 
     messages.on.link(function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1351776360');
-      assert.equal(true, message.MsgType === 'link');
-      assert.equal(true, message.Title === '公众平台官网链接');
-      assert.equal(true, message.Description === '公众平台官网链接');
-      assert.equal(true, message.Url === 'url');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1351776360');
+      assert.strictEqual(true, message.MsgType === 'link');
+      assert.strictEqual(true, message.Title === '公众平台官网链接');
+      assert.strictEqual(true, message.Description === '公众平台官网链接');
+      assert.strictEqual(true, message.Url === 'url');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/link.xml'));
@@ -183,16 +190,16 @@ describe('node-weixin-message', function() {
     messages.on.link(B);
 
     messages.on.link(function(message) {
-      assert.equal(true, AVisited);
-      assert.equal(true, BVisited);
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1351776360');
-      assert.equal(true, message.MsgType === 'link');
-      assert.equal(true, message.Title === '公众平台官网链接');
-      assert.equal(true, message.Description === '公众平台官网链接');
-      assert.equal(true, message.Url === 'url');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, AVisited);
+      assert.strictEqual(true, BVisited);
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1351776360');
+      assert.strictEqual(true, message.MsgType === 'link');
+      assert.strictEqual(true, message.Title === '公众平台官网链接');
+      assert.strictEqual(true, message.Description === '公众平台官网链接');
+      assert.strictEqual(true, message.Url === 'url');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/link.xml'));
@@ -215,7 +222,7 @@ describe('node-weixin-message', function() {
     messages.on.link(A);
     messages.on.link(A);
     messages.on.link(function() {
-      assert.equal(true, time === 1);
+      assert.strictEqual(true, time === 1);
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/link.xml'));
@@ -238,7 +245,7 @@ describe('node-weixin-message', function() {
     messages.on.link(A);
     messages.on.link(A);
     messages.on.link(function() {
-      assert.equal(true, time === 1);
+      assert.strictEqual(true, time === 1);
       done();
     });
     var xml = fs.readFileSync(path.resolve(__dirname, './messages/link.xml'));
@@ -257,7 +264,7 @@ describe('node-weixin-message', function() {
     var r2 = {};
     r2.send = function() {
       count--;
-      assert.equal(true, time + count === 100);
+      assert.strictEqual(true, time + count === 100);
       if (count > 1) {
         http(r1, r2);
       } else {
@@ -290,14 +297,14 @@ describe('node-weixin-message', function() {
     var r1 = {};
     var r2 = {};
     r2.send = function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1351776360');
-      assert.equal(true, message.MsgType === 'link');
-      assert.equal(true, message.Title === '公众平台官网链接');
-      assert.equal(true, message.Description === '公众平台官网链接');
-      assert.equal(true, message.Url === 'url');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1351776360');
+      assert.strictEqual(true, message.MsgType === 'link');
+      assert.strictEqual(true, message.Title === '公众平台官网链接');
+      assert.strictEqual(true, message.Description === '公众平台官网链接');
+      assert.strictEqual(true, message.Url === 'url');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
       done();
     };
 
@@ -305,7 +312,7 @@ describe('node-weixin-message', function() {
       var messages = nodeWeixinMessage.messages;
 
       function A(message, res) {
-        assert.equal(res, r2);
+        assert.strictEqual(res, r2);
         res.send(message);
       }
       messages.on.link(A);
@@ -324,21 +331,21 @@ describe('node-weixin-message', function() {
     var r1 = {};
     var r2 = {};
     r2.send = function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1351776360');
-      assert.equal(true, message.MsgType === 'link');
-      assert.equal(true, message.Title === '公众平台官网链接');
-      assert.equal(true, message.Description === '公众平台官网链接');
-      assert.equal(true, message.Url === 'url');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1351776360');
+      assert.strictEqual(true, message.MsgType === 'link');
+      assert.strictEqual(true, message.Title === '公众平台官网链接');
+      assert.strictEqual(true, message.Description === '公众平台官网链接');
+      assert.strictEqual(true, message.Url === 'url');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
     };
 
     function http(req, res) {
       var messages = nodeWeixinMessage.messages;
       function A(message, res, cb, more) {
-        assert.equal(res, r2);
-        assert.equal(more, 'and more');
+        assert.strictEqual(res, r2);
+        assert.strictEqual(more, 'and more');
         res.send(message);
         cb();
       }
@@ -360,19 +367,19 @@ describe('node-weixin-message', function() {
     var r1 = {};
     var r2 = {};
     r2.send = function(message) {
-      assert.equal(true, message.FromUserName === 'fromUser');
-      assert.equal(true, message.ToUserName === 'toUser');
-      assert.equal(true, message.CreateTime === '1351776360');
-      assert.equal(true, message.MsgType === 'link');
-      assert.equal(true, message.Title === '公众平台官网链接');
-      assert.equal(true, message.Description === '公众平台官网链接');
-      assert.equal(true, message.Url === 'url');
-      assert.equal(true, message.MsgId === '1234567890123456');
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1351776360');
+      assert.strictEqual(true, message.MsgType === 'link');
+      assert.strictEqual(true, message.Title === '公众平台官网链接');
+      assert.strictEqual(true, message.Description === '公众平台官网链接');
+      assert.strictEqual(true, message.Url === 'url');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
     };
     var messages = nodeWeixinMessage.messages;
     function A(message, res, cb, more) {
-      assert.equal(res, r2);
-      assert.equal(more, 'and more');
+      assert.strictEqual(res, r2);
+      assert.strictEqual(more, 'and more');
       res.send(message);
       cb();
     }
@@ -385,5 +392,28 @@ describe('node-weixin-message', function() {
       }, 'and more');
     }
     http(r1, r2);
+  });
+
+  it('should be able to parse encrypted xml', function(done) {
+    var messages = nodeWeixinMessage.messages;
+
+    var query = { encrypt_type: 'aes' };
+
+    messages.on.text(function(message) {
+      assert.strictEqual(true, message.FromUserName === 'fromUser');
+      assert.strictEqual(true, message.ToUserName === 'toUser');
+      assert.strictEqual(true, message.CreateTime === '1348831860');
+      assert.strictEqual(true, message.MsgType === 'text');
+      assert.strictEqual(true, message.Content === 'this is a test');
+      assert.strictEqual(true, message.MsgId === '1234567890123456');
+      done();
+    });
+    var xml = fs.readFileSync(path.resolve(__dirname, './messages/encrypt_text.xml'));
+    x2j.parseString(xml, {
+      explicitArray: false,
+      ignoreAttrs: true
+    }, function(error, json) {
+      messages.parseEncrypt(app.APP_TOKEN, app.APP_ENCODINGAESKEY, query, json);
+    });
   });
 });

--- a/test/incoming.js
+++ b/test/incoming.js
@@ -343,6 +343,7 @@ describe('node-weixin-message', function() {
 
     function http(req, res) {
       var messages = nodeWeixinMessage.messages;
+
       function A(message, res, cb, more) {
         assert.strictEqual(res, r2);
         assert.strictEqual(more, 'and more');
@@ -377,6 +378,7 @@ describe('node-weixin-message', function() {
       assert.strictEqual(true, message.MsgId === '1234567890123456');
     };
     var messages = nodeWeixinMessage.messages;
+
     function A(message, res, cb, more) {
       assert.strictEqual(res, r2);
       assert.strictEqual(more, 'and more');
@@ -397,7 +399,9 @@ describe('node-weixin-message', function() {
   it('should be able to parse encrypted xml', function(done) {
     var messages = nodeWeixinMessage.messages;
 
-    var query = { encrypt_type: 'aes' };
+    var query = {
+      encrypt_type: 'aes'
+    };
 
     messages.on.text(function(message) {
       assert.strictEqual(true, message.FromUserName === 'fromUser');

--- a/test/messages/encrypt_text.xml
+++ b/test/messages/encrypt_text.xml
@@ -1,0 +1,4 @@
+<xml>
+  <ToUserName><![CDATA[toUser]]></ToUserName>
+  <Encrypt><![CDATA[encrypt]]></Encrypt>
+</xml>

--- a/test/reply.js
+++ b/test/reply.js
@@ -18,11 +18,11 @@ describe('node-weixin-message should reply', function() {
       ignoreAttrs: true
     }, function(error, data) {
       var json = data.xml;
-      assert.equal(true, json.FromUserName === 'a');
-      assert.equal(true, json.ToUserName === 'b');
-      assert.equal(true, json.MsgType === 'text');
-      assert.equal(true, json.Content === 'content');
-      assert.equal(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
+      assert.strictEqual(true, json.FromUserName === 'a');
+      assert.strictEqual(true, json.ToUserName === 'b');
+      assert.strictEqual(true, json.MsgType === 'text');
+      assert.strictEqual(true, json.Content === 'content');
+      assert.strictEqual(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
       done();
     });
   });
@@ -36,11 +36,11 @@ describe('node-weixin-message should reply', function() {
       ignoreAttrs: true
     }, function(error, data) {
       var json = data.xml;
-      assert.equal(true, json.FromUserName === 'a');
-      assert.equal(true, json.ToUserName === 'b');
-      assert.equal(true, json.MsgType === 'image');
-      assert.equal(true, json.Image.MediaId === 'mediaId');
-      assert.equal(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
+      assert.strictEqual(true, json.FromUserName === 'a');
+      assert.strictEqual(true, json.ToUserName === 'b');
+      assert.strictEqual(true, json.MsgType === 'image');
+      assert.strictEqual(true, json.Image.MediaId === 'mediaId');
+      assert.strictEqual(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
       done();
     });
   });
@@ -53,11 +53,11 @@ describe('node-weixin-message should reply', function() {
       ignoreAttrs: true
     }, function(error, data) {
       var json = data.xml;
-      assert.equal(true, json.FromUserName === 'a');
-      assert.equal(true, json.ToUserName === 'b');
-      assert.equal(true, json.MsgType === 'voice');
-      assert.equal(true, json.Voice.MediaId === 'mediaId');
-      assert.equal(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
+      assert.strictEqual(true, json.FromUserName === 'a');
+      assert.strictEqual(true, json.ToUserName === 'b');
+      assert.strictEqual(true, json.MsgType === 'voice');
+      assert.strictEqual(true, json.Voice.MediaId === 'mediaId');
+      assert.strictEqual(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
       done();
     });
   });
@@ -70,13 +70,13 @@ describe('node-weixin-message should reply', function() {
       ignoreAttrs: true
     }, function(error, data) {
       var json = data.xml;
-      assert.equal(true, json.FromUserName === 'a');
-      assert.equal(true, json.ToUserName === 'b');
-      assert.equal(true, json.MsgType === 'video');
-      assert.equal(true, json.Video.MediaId === 'mediaId');
-      assert.equal(true, json.Video.Title === 'title');
-      assert.equal(true, json.Video.Description === 'desc');
-      assert.equal(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
+      assert.strictEqual(true, json.FromUserName === 'a');
+      assert.strictEqual(true, json.ToUserName === 'b');
+      assert.strictEqual(true, json.MsgType === 'video');
+      assert.strictEqual(true, json.Video.MediaId === 'mediaId');
+      assert.strictEqual(true, json.Video.Title === 'title');
+      assert.strictEqual(true, json.Video.Description === 'desc');
+      assert.strictEqual(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
       done();
     });
   });
@@ -90,15 +90,15 @@ describe('node-weixin-message should reply', function() {
       ignoreAttrs: true
     }, function(error, data) {
       var json = data.xml;
-      assert.equal(true, json.FromUserName === 'a');
-      assert.equal(true, json.ToUserName === 'b');
-      assert.equal(true, json.MsgType === 'music');
-      assert.equal(true, json.Music.ThumbMediaId === 'mediaId');
-      assert.equal(true, json.Music.Title === 'title');
-      assert.equal(true, json.Music.Description === 'desc');
-      assert.equal(true, json.Music.MusicUrl === 'http://www.music1.com');
-      assert.equal(true, json.Music.HQMusicUrl === 'http://www.music2.com');
-      assert.equal(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
+      assert.strictEqual(true, json.FromUserName === 'a');
+      assert.strictEqual(true, json.ToUserName === 'b');
+      assert.strictEqual(true, json.MsgType === 'music');
+      assert.strictEqual(true, json.Music.ThumbMediaId === 'mediaId');
+      assert.strictEqual(true, json.Music.Title === 'title');
+      assert.strictEqual(true, json.Music.Description === 'desc');
+      assert.strictEqual(true, json.Music.MusicUrl === 'http://www.music1.com');
+      assert.strictEqual(true, json.Music.HQMusicUrl === 'http://www.music2.com');
+      assert.strictEqual(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
       done();
     });
   });
@@ -126,22 +126,22 @@ describe('node-weixin-message should reply', function() {
       ignoreAttrs: true
     }, function(error, data) {
       var json = data.xml;
-      assert.equal(true, json.FromUserName === 'a');
-      assert.equal(true, json.ToUserName === 'b');
-      assert.equal(true, json.MsgType === 'news');
-      assert.equal(true, json.ArticleCount === '3');
-      assert.equal(true, json.Articles.item.length === 3);
-      assert.equal(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
+      assert.strictEqual(true, json.FromUserName === 'a');
+      assert.strictEqual(true, json.ToUserName === 'b');
+      assert.strictEqual(true, json.MsgType === 'news');
+      assert.strictEqual(true, json.ArticleCount === '3');
+      assert.strictEqual(true, json.Articles.item.length === 3);
+      assert.strictEqual(true, new Date(parseInt(json.CreateTime, 10)).getTime() > 0);
 
       var items = json.Articles.item;
       for (var i = 0; i < items.length; i++) {
         var item = items[i];
         var idx = i + 1;
 
-        assert.equal(true, item.Title === 'title' + idx);
-        assert.equal(true, item.Description === 'description' + idx);
-        assert.equal(true, item.PicUrl === 'picUrl' + idx);
-        assert.equal(true, item.Url === 'url' + idx);
+        assert.strictEqual(true, item.Title === 'title' + idx);
+        assert.strictEqual(true, item.Description === 'description' + idx);
+        assert.strictEqual(true, item.PicUrl === 'picUrl' + idx);
+        assert.strictEqual(true, item.Url === 'url' + idx);
       }
       done();
     });

--- a/test/template.js
+++ b/test/template.js
@@ -14,8 +14,8 @@ describe('node-weixin-message', function () {
     var templateId = null;
     it('it should be able to set industry', function (done) {
       nodeWeixinMessage.template.setIndustry(settings, app, '1', '2', function (error, data) {
-        assert.equal(true, !error);
-        assert.equal(true, (data.errcode === 0 && data.errmsg === 'ok') ||
+        assert.strictEqual(true, !error);
+        assert.strictEqual(true, (data.errcode === 0 && data.errmsg === 'ok') ||
           (data.errcode === 43100 && data.errmsg.indexOf('change template too frequently hint') !== -1));
         done();
       });
@@ -24,12 +24,12 @@ describe('node-weixin-message', function () {
     it('it should be able to get template', function (done) {
       nodeWeixinMessage.template.get(settings, app, 'TM00015', function (error, data) {
         templateId = data.template_id;
-        assert.equal(true, !error);
+        assert.strictEqual(true, !error);
         if (data.errcode !== 45026) {
-          assert.equal(true, data.errcode === 0);
-          assert.equal(true, data.errmsg === 'ok');
-          assert.equal(true, typeof data.template_id === 'string');
-          assert.equal(true, data.template_id.length > 1);
+          assert.strictEqual(true, data.errcode === 0);
+          assert.strictEqual(true, data.errmsg === 'ok');
+          assert.strictEqual(true, typeof data.template_id === 'string');
+          assert.strictEqual(true, data.template_id.length > 1);
         }
         done();
       });
@@ -54,13 +54,13 @@ describe('node-weixin-message', function () {
           color: '#173177'
         }
       }, function (error, data) {
-        assert.equal(true, !error);
+        assert.strictEqual(true, !error);
         if (data.errcode === 40036) {
           console.error(error, data);
         } else {
-          assert.equal(true, data.errcode === 0);
-          assert.equal(true, data.errmsg === 'ok');
-          assert.equal(true, data.msgid > 1);
+          assert.strictEqual(true, data.errcode === 0);
+          assert.strictEqual(true, data.errmsg === 'ok');
+          assert.strictEqual(true, data.msgid > 1);
         }
         done();
       });


### PR DESCRIPTION
When use Secure Mode in weixin-message server configration, server will receive xml like :
```
<xml>
<ToUserName></ToUserName>
<Encrypt></Encrypt>
</xml>
```
Then we can use nodeWeixinMessage.messages.parseEncrypt() to handle the encrypted message.